### PR TITLE
Issue #66: Refresh Pages on Pop if Data May Have Changed

### DIFF
--- a/app/pages/amigo-requests/amigo-requests.spec.ts
+++ b/app/pages/amigo-requests/amigo-requests.spec.ts
@@ -3,6 +3,7 @@ import {AmigoRequestsPage} from "./amigo-requests";
 import {AmigoShareRequest} from "../../amigo-share-request/amigo-share-request";
 import {AMIGO_SHARE_REQUESTS} from "../../amigo-share-request-service/amigo-share-request.mocks";
 import {AmigoShareRequestService} from "../../amigo-share-request-service/amigo-share-request.service";
+import {Events} from "ionic-angular/index";
 
 class MockAmigoShareRequestService {
 
@@ -10,6 +11,14 @@ class MockAmigoShareRequestService {
         return Promise.resolve(
             AMIGO_SHARE_REQUESTS
         );
+    }
+
+}
+
+class MockEvents {
+
+    subscribe(topic: string, ...handlers: Function[]): void {
+
     }
 
 }
@@ -23,8 +32,11 @@ describe("AmigoPage", () => {
 
         const mockAmigoShareRequestService: AmigoShareRequestService = new MockAmigoShareRequestService() as AmigoShareRequestService;
 
+        const mockEvents: Events = new MockEvents() as Events;
+
         const requestPage: AmigoRequestsPage = new AmigoRequestsPage(
-            mockAmigoShareRequestService
+            mockAmigoShareRequestService,
+            mockEvents
         );
 
         return requestPage.ngOnInit().then(

--- a/app/pages/amigo-requests/amigo-requests.ts
+++ b/app/pages/amigo-requests/amigo-requests.ts
@@ -5,6 +5,7 @@ import {AmigoShareRequest} from "../../amigo-share-request/amigo-share-request";
 import {AmigoShareRequestCardComponent} from "../../amigo-share-request-card/amigo-share-request-card.component";
 import {AmigoRequestCreateComponent} from "../../amigo-request-create-component/amigo-request-create.component";
 import {LogonPanelComponent} from "../../logon-panel-component/logon-panel.component";
+import {Events} from "ionic-angular/index";
 
 @Component(
     {
@@ -28,22 +29,39 @@ export class AmigoRequestsPage implements OnInit {
     public decline: (AmigoShareRequest) => void;
 
     constructor(
-        private amigoShareRequestService: AmigoShareRequestService
+        private amigoShareRequestService: AmigoShareRequestService,
+        private events: Events
     ) {
         this.accept = this.acceptAmigoShareRequest.bind(this);
         this.decline = this.declineAmigoShareRequest.bind(this);
+
+        /* Refresh page data when a new request is created. */
+        events.subscribe(
+            "amigoShareRequest:created",
+            () => {
+                this.loadRequests();
+            }
+        );
     }
 
     /**
-     * Initialize the page.
-     * @returns {Promise}
+     * Loads and sets requests.
+     * @returns {any}.
      */
-    public ngOnInit(): any {
+    public loadRequests(): any {
         return this.amigoShareRequestService.list().then(
             amigoShareRequests => {
                 this.amigoShareRequests = amigoShareRequests;
             }
         );
+    }
+
+    /**
+     * Initialize the page.
+     * @returns {Promise}.
+     */
+    public ngOnInit(): any {
+        return this.loadRequests();
     }
 
     private saveAmigoShareRequest(

--- a/app/pages/amigos/amigos.spec.ts
+++ b/app/pages/amigos/amigos.spec.ts
@@ -3,6 +3,7 @@ import {AmigosPage} from "./amigos";
 import {DoseAmigosUser} from "../../dose-amigos-user/dose-amigos-user";
 import {DOSE_AMIGOS_USERS} from "../../dose-amigos-user-service/dose-amigos-user-mocks";
 import {DoseAmigosUserService} from "../../dose-amigos-user-service/dose-amigos-user.service";
+import {Events} from "ionic-angular/index";
 
 class MockDoseAmigosUserService {
 
@@ -10,6 +11,14 @@ class MockDoseAmigosUserService {
         return Promise.resolve(
             DOSE_AMIGOS_USERS
         );
+    }
+
+}
+
+class MockEvents {
+
+    subscribe(topic: string, ...handlers: Function[]): void {
+
     }
 
 }
@@ -23,8 +32,11 @@ describe("AmigoPage", () => {
 
         const mockDoseAmigosUserService: DoseAmigosUserService = new MockDoseAmigosUserService() as DoseAmigosUserService;
 
+        const mockEvents: Events = new MockEvents() as Events;
+
         const amigosPage: AmigosPage = new AmigosPage(
-            mockDoseAmigosUserService
+            mockDoseAmigosUserService,
+            mockEvents
         );
 
         return amigosPage.ngOnInit().then(
@@ -44,8 +56,11 @@ describe("AmigoPage", () => {
 
         const mockDoseAmigosUserService: DoseAmigosUserService = new MockDoseAmigosUserService() as DoseAmigosUserService;
 
+        const mockEvents: Events = new MockEvents() as Events;
+
         const amigosPage: AmigosPage = new AmigosPage(
-            mockDoseAmigosUserService
+            mockDoseAmigosUserService,
+            mockEvents
         );
 
         return amigosPage.ngOnInit().then(

--- a/app/pages/amigos/amigos.ts
+++ b/app/pages/amigos/amigos.ts
@@ -6,6 +6,7 @@ import {UserStatusCardComponent} from "../../user-status-card/user-status-card.c
 import {FeedPage} from "../feed/feed";
 import {AmigoRequestCreateComponent} from "../../amigo-request-create-component/amigo-request-create.component";
 import {LogonPanelComponent} from "../../logon-panel-component/logon-panel.component";
+import {Events} from "ionic-angular/index";
 
 @Component(
     {
@@ -25,9 +26,30 @@ export class AmigosPage implements OnInit {
     public userStatusClickPage: Type;
 
     constructor(
-        private doseAmigosUserService: DoseAmigosUserService
+        private doseAmigosUserService: DoseAmigosUserService,
+        private events: Events
     ) {
 
+        /* Refresh page data when a new request is created. */
+        events.subscribe(
+            "amigoShareRequest:created",
+            () => {
+                this.loadUsers();
+            }
+        );
+
+    }
+
+    /**
+     * Loads and sets users.
+     * @returns {any}.
+     */
+    public loadUsers(): any {
+        return this.doseAmigosUserService.list().then(
+            doseAmigosUsers => {
+                this.doseAmigosUsers = doseAmigosUsers;
+            }
+        );
     }
 
     /**
@@ -38,11 +60,7 @@ export class AmigosPage implements OnInit {
 
         this.userStatusClickPage = FeedPage;
 
-        return this.doseAmigosUserService.list().then(
-            doseAmigosUsers => {
-                this.doseAmigosUsers = doseAmigosUsers;
-            }
-        );
+        return this.loadUsers();
     }
 
 }

--- a/app/pages/med-list/med-list.spec.ts
+++ b/app/pages/med-list/med-list.spec.ts
@@ -3,6 +3,7 @@ import {MedListPage} from "./med-list";
 import {DOSE_MEDICATIONS} from "../../dose-medication-service/dose-medication-mocks";
 import {DoseMedication} from "../../dose-medication/dose-medication";
 import {DoseMedicationService} from "../../dose-medication-service/dose-medication.service";
+import {Events} from "ionic-angular/index";
 
 
 class MockDoseMedicationService {
@@ -11,6 +12,14 @@ class MockDoseMedicationService {
         return Promise.resolve(
             DOSE_MEDICATIONS
         );
+    }
+
+}
+
+class MockEvents {
+
+    subscribe(topic: string, ...handlers: Function[]): void {
+
     }
 
 }
@@ -24,8 +33,11 @@ describe("MedListPage", () => {
 
         const mockDoseMedicationService: DoseMedicationService = new MockDoseMedicationService() as DoseMedicationService;
 
+        const mockEvents: Events = new MockEvents() as Events;
+
         const medListPage: MedListPage = new MedListPage(
-            mockDoseMedicationService
+            mockDoseMedicationService,
+            mockEvents
         );
 
         return medListPage.ngOnInit().then(
@@ -45,8 +57,11 @@ describe("MedListPage", () => {
 
         const mockDoseMedicationService: DoseMedicationService = new MockDoseMedicationService() as DoseMedicationService;
 
+        const mockEvents: Events = new MockEvents() as Events;
+
         const medListPage: MedListPage = new MedListPage(
-            mockDoseMedicationService
+            mockDoseMedicationService,
+            mockEvents
         );
 
         return medListPage.ngOnInit().then(

--- a/app/pages/med-list/med-list.ts
+++ b/app/pages/med-list/med-list.ts
@@ -1,9 +1,10 @@
-import {Component, OnInit, Type} from "@angular/core";
+import {Component, OnInit} from "@angular/core";
 import {DoseAmigosToolbar} from "../../dose-amigos-toolbar/dose-amigos-toolbar.component";
 import {MedListComponenet} from "../../med-list-event/med-list-event.component";
 import {DoseMedication} from "../../dose-medication/dose-medication";
 import {DoseMedicationService} from "../../dose-medication-service/dose-medication.service";
 import {MedListCreateComponent} from "../../med-list-create-component/med-list-create.component";
+import {Events} from "ionic-angular/index";
 
 
 @Component(
@@ -22,17 +23,30 @@ export class MedListPage implements OnInit {
     public doseMedications: Array<DoseMedication> = [];
 
     constructor(
-        private doseMedicationService: DoseMedicationService
-    ) {}
+        private doseMedicationService: DoseMedicationService,
+        private events: Events
+    ) {
 
-    public ngOnInit(): any {
+        /* Refresh page data when a new doseSeries is created. */
+        events.subscribe(
+            "doseSeries:created",
+            () => {
+                this.loadMedicationList();
+            }
+        );
 
+    }
+
+    public loadMedicationList(): any {
         return this.doseMedicationService.list().then(
             doseMedications => {
                 this.doseMedications = doseMedications;
             }
         );
+    }
 
+    public ngOnInit(): any {
+        return this.loadMedicationList();
     }
 
 }

--- a/app/pages/new-amigo-request/new-amigo-request.spec.ts
+++ b/app/pages/new-amigo-request/new-amigo-request.spec.ts
@@ -1,5 +1,5 @@
 import {it, describe, expect} from "@angular/core/testing";
-import {NavController} from "ionic-angular/index";
+import {NavController, Events} from "ionic-angular/index";
 import {NewAmigoRequestPage} from "./new-amigo-request";
 import {AmigoShareRequestService} from "../../amigo-share-request-service/amigo-share-request.service";
 
@@ -10,6 +10,14 @@ class MockNavController {
 }
 
 class MockAmigoShareRequestService {
+
+}
+
+class MockEvents {
+
+    publish(topic: string, ...args: any[]): any[] {
+        return [];
+    }
 
 }
 
@@ -24,9 +32,12 @@ describe("NewAmigoRequestPage", () => {
 
         const amigoShareRequestService: AmigoShareRequestService = new MockAmigoShareRequestService() as AmigoShareRequestService;
 
+        const mockEvents: Events = new MockEvents() as Events;
+
         const newAmigoRequestPage: NewAmigoRequestPage = new NewAmigoRequestPage(
             mockNavController,
-            amigoShareRequestService
+            amigoShareRequestService,
+            mockEvents
         );
 
         return newAmigoRequestPage.ngOnInit().then(

--- a/app/pages/new-amigo-request/new-amigo-request.ts
+++ b/app/pages/new-amigo-request/new-amigo-request.ts
@@ -1,7 +1,7 @@
 import {DoseAmigosToolbar} from "../../dose-amigos-toolbar/dose-amigos-toolbar.component";
 import {Component, OnInit} from "@angular/core";
 import {AmigoShareRequest} from "../../amigo-share-request/amigo-share-request";
-import {NavController} from "ionic-angular/index";
+import {NavController, Events} from "ionic-angular/index";
 import {LogonPanelComponent} from "../../logon-panel-component/logon-panel.component";
 import {AmigoShareRequestService} from "../../amigo-share-request-service/amigo-share-request.service";
 
@@ -22,7 +22,8 @@ export class NewAmigoRequestPage implements OnInit {
 
     constructor(
         private nav: NavController,
-        private amigoShareRequestService: AmigoShareRequestService
+        private amigoShareRequestService: AmigoShareRequestService,
+        private events: Events
     ) {
 
     }
@@ -36,13 +37,19 @@ export class NewAmigoRequestPage implements OnInit {
         );
     }
 
-    public onSubmit(): Promise<AmigoShareRequest> {
+    public onSubmit(): any {
         return this.amigoShareRequestService.save(
             this.amigoShareRequest
         ).then(
-            function () {
+            (amigoShareRequest: AmigoShareRequest) => {
+
+                this.events.publish(
+                    "amigoShareRequest:created",
+                    amigoShareRequest as AmigoShareRequest
+                );
+
                 this.nav.pop();
-            }.bind(this)
+            }
         );
     }
 

--- a/app/pages/new-dose-medication/new-dose-medication.spec.ts
+++ b/app/pages/new-dose-medication/new-dose-medication.spec.ts
@@ -1,5 +1,5 @@
 import {it, describe, expect} from "@angular/core/testing";
-import {NavController} from "ionic-angular/index";
+import {NavController, Events} from "ionic-angular/index";
 import {NewDoseMedicationPage} from "./new-dose-medication";
 import {DoseSeriesService} from "../../dose-series-service/dose-series.service";
 import {DoseSeries} from "../../dose-series/dose-series";
@@ -33,6 +33,14 @@ class MockDoseAmigosUserService {
 
 }
 
+class MockEvents {
+
+    publish(topic: string, ...args: any[]): any[] {
+        return [];
+    }
+
+}
+
 /**
  * Tests for NewDoseMedicationPage component.
  */
@@ -46,10 +54,13 @@ describe("NewDoseMedicationPage", () => {
 
         const mockDoseAmigosUserService: DoseAmigosUserService = new MockDoseAmigosUserService() as DoseAmigosUserService;
 
+        const mockEvents: Events = new MockEvents() as Events;
+
         const newDoseMedicationPage: NewDoseMedicationPage = new NewDoseMedicationPage(
             mockNavController,
             mockDoseSeriesService,
-            mockDoseAmigosUserService
+            mockDoseAmigosUserService,
+            mockEvents
         );
 
         return newDoseMedicationPage.ngOnInit().then(

--- a/app/pages/new-dose-medication/new-dose-medication.ts
+++ b/app/pages/new-dose-medication/new-dose-medication.ts
@@ -2,7 +2,7 @@ import {DoseAmigosToolbar} from "../../dose-amigos-toolbar/dose-amigos-toolbar.c
 import {Component, OnInit} from "@angular/core";
 import {DoseMedication} from "../../dose-medication/dose-medication";
 import {DoseSeries} from "../../dose-series/dose-series";
-import {NavController} from "ionic-angular/index";
+import {NavController, Events} from "ionic-angular/index";
 import {DoseSeriesService} from "../../dose-series-service/dose-series.service";
 import * as moment from "moment";
 import {DoseAmigosUserService} from "../../dose-amigos-user-service/dose-amigos-user.service";
@@ -25,7 +25,8 @@ export class NewDoseMedicationPage implements OnInit {
     constructor(
         private nav: NavController,
         private doseSeriesService: DoseSeriesService,
-        private doseAmigosUserService: DoseAmigosUserService
+        private doseAmigosUserService: DoseAmigosUserService,
+        private events: Events
     ) {
 
     }
@@ -48,7 +49,7 @@ export class NewDoseMedicationPage implements OnInit {
         );
     }
 
-    public onSubmit(): Promise<DoseSeries> {
+    public onSubmit(): any {
 
         if (this.everyday) {
             this.doseSeries.daysOfWeek = [1, 2, 3, 4, 5, 6, 7];
@@ -63,10 +64,14 @@ export class NewDoseMedicationPage implements OnInit {
         return this.doseSeriesService.save(
             this.doseSeries
         ).then(
-            (data) => {
-                this.nav.pop();
+            (doseSeries: DoseSeries) => {
 
-                return data;
+                this.events.publish(
+                    "doseSeries:created",
+                    doseSeries as DoseSeries
+                );
+
+                this.nav.pop();
             }
         );
     }


### PR DESCRIPTION
In the places where we push/pop pages onto the Nav stack,
if the data has changed, publish an event.
The pages behind the new page will subscribe to this event,
and refresh their data when it is fired.

This was changed for the new-dose-medication page, which
fires an event that refreshes the med-list page.

This was changed for new-amigo-request, which fires an event
that refreshes the amigos and requests pages.