### PR TITLE
Issue #70: Fix Logon bug.

### DIFF
--- a/app/auth-service/auth.service.ts
+++ b/app/auth-service/auth.service.ts
@@ -1,4 +1,4 @@
-import {Storage, LocalStorage} from "ionic-angular";
+import {Storage, LocalStorage, Events} from "ionic-angular";
 import {Injectable, NgZone} from "@angular/core";
 import {Observable} from "rxjs/Rx";
 import "../rxjs-operators";
@@ -22,7 +22,8 @@ export class AuthService {
 
     constructor(
         private authHttp: AuthHttp,
-        private zoneImpl: NgZone
+        private zoneImpl: NgZone,
+        private events: Events
     ) {
 
         this.lock = new Auth0Lock(
@@ -64,6 +65,11 @@ export class AuthService {
                 this.zoneImpl.run(() => this.user = profile);
                 // Schedule a token refresh
                 this.scheduleRefresh();
+
+                /* Fire logon event. */
+                this.events.publish(
+                    "user:authenticated"
+                );
             }
         );
     }

--- a/app/dose-amigos-user-service/dose-amigos-user.service.ts
+++ b/app/dose-amigos-user-service/dose-amigos-user.service.ts
@@ -11,9 +11,6 @@ export class DoseAmigosUserService {
 
     private amigosUsersUrl: string = `${BACKEND_URL}/amigo-users`;
 
-    /* Cached currentUser so we don't have to get from server again. */
-    private currentUser: DoseAmigosUser;
-
     constructor(
         private http: AuthHttp
     ) {
@@ -56,22 +53,12 @@ export class DoseAmigosUserService {
      */
     public getCurrent(): Promise<DoseAmigosUser> {
 
-        if (this.currentUser) {
-            /* Return cached value. */
-            return Promise.resolve(this.currentUser);
-        }
-
         /* Get from server. */
         return this.http.get(
             `${this.amigosUsersUrl}/current`
         ).toPromise().then(
             (response) => {
-                let user = response.json();
-
-                /* Cache it for later requests. */
-                this.currentUser = user;
-
-                return user;
+                return response.json();
             }
         ).catch(
             this.handleError

--- a/app/logon-panel-component/logon-panel.scss
+++ b/app/logon-panel-component/logon-panel.scss
@@ -13,5 +13,5 @@
 }
 
 .slogan {
-  color: color($colors, secondary);
+
 }

--- a/app/pages/feed/feed.ts
+++ b/app/pages/feed/feed.ts
@@ -9,8 +9,9 @@ import {LogonPanelComponent} from "../../logon-panel-component/logon-panel.compo
 import {DoseAmigosUser} from "../../dose-amigos-user/dose-amigos-user";
 import {DoseAmigosUserService} from "../../dose-amigos-user-service/dose-amigos-user.service";
 import {LoadingStatusService} from "../../loading-status-service/loading-status.service";
-import {NavController} from "ionic-angular/index";
+import {NavController, Events} from "ionic-angular/index";
 import {LoadingStatus} from "../../loading-status/loading-status";
+import {AuthService} from "../../auth-service/auth.service";
 
 /**
  * Component that renders the Amigos Feed Page of dose events.
@@ -37,9 +38,17 @@ export class FeedPage implements OnInit {
         private feedEventService: FeedEventService,
         private doseAmigosUserService: DoseAmigosUserService,
         private nav: NavController,
-        private loadingStatusService: LoadingStatusService
+        private loadingStatusService: LoadingStatusService,
+        private auth: AuthService,
+        private events: Events
     ) {
-
+        /* Refresh page data when a user logs in. */
+        events.subscribe(
+            "user:authenticated",
+            () => {
+                this.loadData();
+            }
+        );
     }
 
     public loadData(): any {
@@ -80,7 +89,9 @@ export class FeedPage implements OnInit {
 
         this.userStatusClickPage = DosePage;
 
-        return this.loadData();
+        if(this.auth.authenticated()) {
+            this.loadData();
+        }
     }
 
 }


### PR DESCRIPTION
Quick bug fix, not ideal solution.
Since the feed page is the most likely page this will occur on,
don't issue the server calls until after the user logs in.
"user:authenticated" event will trigger the reload attempt.

Also removes the caching of the current user.
If this fails, we are stuck with bad user data.
Also since this contains the dose information, we need it to refresh.

Changes slogan text color now that theme colors changed.