### PR TITLE
Issue #80 Change shortTime to medium to add the date to the Dose screen

### DIFF
--- a/app/pages/dose/dose.html
+++ b/app/pages/dose/dose.html
@@ -9,7 +9,7 @@
             </button>
         </ion-buttons>
         <ion-title style="text-align:center" *ngIf="doseEvents[0]">
-            {{doseEvents[0].scheduledDateTime | date:'shortTime' }}
+            {{doseEvents[0].scheduledDateTime | date:'medium' }}
         </ion-title>
         <ion-buttons right>
             <button (click)="loadNext()">


### PR DESCRIPTION
Closes Issue #80 Change the time at the top of the dose screen to be a date and time.